### PR TITLE
Add the OLM config template

### DIFF
--- a/olm/olmconfig.yaml
+++ b/olm/olmconfig.yaml
@@ -1,0 +1,34 @@
+# This configuration is a placeholder. Replace any values with relevant values for your
+# service controller project.
+---
+annotations:
+  capabilityLevel: basic install
+  shortDescription: AWS {SERVICE} controller is a service controller for managing {SERVICE} resources
+    in Kubernetes
+displayName: AWS Controllers for Kubernetes - Amazon {SERVICE}
+description: |-
+  Manage Amazon {SERVICE} resources in AWS from within your Kubernetes cluster.
+
+
+  **About Amazon {SERVICE}**
+
+
+  {ADD YOUR DESCRIPTION HERE}
+
+
+  **About the AWS Controllers for Kubernetes**
+
+
+  This controller is a component of the [AWS Controller for Kubernetes](https://github.com/aws/aws-controllers-k8s)
+  project. This project is currently in **developer preview**. 
+samples:
+- kind: ExampleCustomKind
+  spec: '{}'
+- kind: SecondExampleCustomKind
+  spec: '{}'
+maintainers:
+- name: "Your Team Name"
+  email: "your-team@example.com"
+links:
+- name: Amazon {SERVICE} Developer Resources
+  url: "{YOUR SERVICE DEVELOPER RESOURCES URL}"


### PR DESCRIPTION
Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>

Issue #, if available:
Related to: https://github.com/aws-controllers-k8s/community/issues/744

Description of changes:

This PR will add the configuration necessary for the `ack-generate olm` subcommand to render the appropriate Operator Lifecycle Manager ("OLM") bundle assets into the repository.

For reference, the PR merging the `olm` subcommand is here: https://github.com/aws-controllers-k8s/code-generator/commit/cb1d017ccc59feaa7ed247df502a2414f37344b2

This configuration informs `ack-generate` on exactly how to lay down a [ClusterServiceVersion](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md) "kustomize" base, which is then used by Operator SDK to generate a bundle to represent a particular version of the project in OLM

As this is the template repository, this file contains placeholders for every slot, and effectively will need to be changed by service-controller maintainers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
