### PR TITLE
Properly capitalize capability level

### DIFF
--- a/olm/olmconfig.yaml
+++ b/olm/olmconfig.yaml
@@ -2,7 +2,7 @@
 # service controller project.
 ---
 annotations:
-  capabilityLevel: basic install
+  capabilityLevel: Basic Install
   shortDescription: AWS {SERVICE} controller is a service controller for managing {SERVICE} resources
     in Kubernetes
 displayName: AWS Controllers for Kubernetes - Amazon {SERVICE}


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
This fixes the rendering of the capability level as it shows up in the OpenShift Console. 

Apologies for the extra commit here. The OperatorHub preview functionality used to test the CSV layout is apparently more lenient than the OpenShift Console rendering in this regard.

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.** 
👍 
