### PR TITLE
Add initial CLI of controller-bootstrap with Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,7 @@ ACK_RUNTIME_VERSION=$(shell curl -H "Accept: application/vnd.github.v3+json" \
 
 .DEFAULT_GOAL=run
 DRY_RUN="false"
-EXISTING_CONTROLLER="true"
-ifeq ($(CONTROLLER_DIR/cmd/controller/main.go),)
-	EXISTING_CONTROLLER="false"
-endif
+EXISTING_CONTROLLER="false"
 
 # Build ldflags
 VERSION ?= "v0.0.0"
@@ -57,6 +54,7 @@ init: generate
 
 run:
 	@if [ -f ${CONTROLLER_DIR}/cmd/controller/main.go ]; then \
+  	  	EXISTING_CONTROLLER="true"; \
 	    make generate; \
 	else \
 	    make init; \

--- a/Makefile
+++ b/Makefile
@@ -3,21 +3,56 @@ SHELL := /bin/bash # Use bash syntax
 # Set up variables
 GO111MODULE=on
 
-# Build ldflags
-VERSION ?= "v0.0.0"
-GITCOMMIT=$(shell git rev-parse HEAD)
-BUILDDATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
-GO_LDFLAGS=-ldflags "-X main.version=$(VERSION) \
-			-X main.buildHash=$(GITCOMMIT) \
-			-X main.buildDate=$(BUILDDATE)"
+GO_CMD_FLAGS=-tags codegen
+AWS_SERVICE=$(shell echo $(SERVICE))
+SERVICE_MODEL_NAME=$(shell echo $(MODEL_NAME))
+ifeq ($(SERVICE_MODEL_NAME),)
+  SERVICE_MODEL_NAME:=""
+endif
+ROOT_DIR=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+CONTROLLER_BOOTSTRAP=./bin/controller-bootstrap
+CONTROLLER_DIR=${ROOT_DIR}/../${AWS_SERVICE}-controller
+CODE_GEN_DIR=${ROOT_DIR}/../code-generator
+AWS_SDK_GO_VERSION=$(shell curl -H "Accept: application/vnd.github.v3+json" \
+                                 https://api.github.com/repos/aws/aws-sdk-go/releases/latest | jq -r '.tag_name')
+ACK_RUNTIME_VERSION=$(shell curl -H "Accept: application/vnd.github.v3+json" \
+								 https://api.github.com/repos/aws-controllers-k8s/runtime/releases/latest | jq -r '.tag_name')
+.DEFAULT_GOAL=run
+EXISTING_CONTROLLER="true"
+DRY_RUN="false"
 
-.PHONY: all test
+.PHONY: build, generate, update, init, run, clean
 
-all: test
+build:
+	@go build ${GO_CMD_FLAGS} -o ${CONTROLLER_BOOTSTRAP} ./cmd/controller-bootstrap/*.go
 
-test: 				## Run code tests
-	go test -v ./...
+generate: build
+	@${CONTROLLER_BOOTSTRAP} generate -r ${ACK_RUNTIME_VERSION} -v ${AWS_SDK_GO_VERSION} -s ${AWS_SERVICE} -d=${DRY_RUN} -o ${ROOT_DIR}/../${AWS_SERVICE}-controller -m ${SERVICE_MODEL_NAME}
 
-help:           	## Show this help.
-	@grep -F -h "##" $(MAKEFILE_LIST) | grep -F -v grep | sed -e 's/\\$$//' \
-		| awk -F'[:#]' '{print $$1 = sprintf("%-30s", $$1), $$4}'
+update: build
+	@${CONTROLLER_BOOTSTRAP} generate -r ${ACK_RUNTIME_VERSION} -v ${AWS_SDK_GO_VERSION} -s ${AWS_SERVICE} -d=${DRY_RUN} -e=${EXISTING_CONTROLLER} -o ${ROOT_DIR}/../${AWS_SERVICE}-controller -m ${SERVICE_MODEL_NAME}
+
+init: generate
+	@export SERVICE=${AWS_SERVICE}
+	@echo "build controller attempt #1"
+	@cd ${CODE_GEN_DIR} && make -i build-controller >/dev/null 2>/dev/null
+	@echo "missing go.sum entry, running go mod tidy"
+	@cd ${CONTROLLER_DIR} && go mod tidy
+	@echo "build controller attempt #2"
+	@cd ${CODE_GEN_DIR} && make -i build-controller >/dev/null 2>/dev/null
+	@echo "go.sum outdated, running go mod tidy"
+	@cd ${CONTROLLER_DIR} && go mod tidy
+	@echo "final build controller attempt"
+	@cd ${CODE_GEN_DIR} && make build-controller
+	@echo "look inside ${SERVICE}-controller/INSTRUCTIONS.md for further instructions"
+
+run:
+	@if [ -f ${CONTROLLER_DIR}/cmd/controller/main.go ]; then \
+	  make update; \
+	else \
+	  make init; \
+	fi
+
+clean:
+	@cd ${CONTROLLER_DIR}
+	@rm -rf ${CONTROLLER_DIR}/..?* ${CONTROLLER_DIR}/.[!.]* ${CONTROLLER_DIR}/*

--- a/Makefile
+++ b/Makefile
@@ -3,56 +3,64 @@ SHELL := /bin/bash # Use bash syntax
 # Set up variables
 GO111MODULE=on
 
-GO_CMD_FLAGS=-tags codegen
 AWS_SERVICE=$(shell echo $(SERVICE))
 SERVICE_MODEL_NAME=$(shell echo $(MODEL_NAME))
 ifeq ($(SERVICE_MODEL_NAME),)
-  SERVICE_MODEL_NAME:=""
+  SERVICE_MODEL_NAME=""
 endif
-ROOT_DIR=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-CONTROLLER_BOOTSTRAP=./bin/controller-bootstrap
-CONTROLLER_DIR=${ROOT_DIR}/../${AWS_SERVICE}-controller
-CODE_GEN_DIR=${ROOT_DIR}/../code-generator
-AWS_SDK_GO_VERSION=$(shell curl -H "Accept: application/vnd.github.v3+json" \
-                                 https://api.github.com/repos/aws/aws-sdk-go/releases/latest | jq -r '.tag_name')
-ACK_RUNTIME_VERSION=$(shell curl -H "Accept: application/vnd.github.v3+json" \
-								 https://api.github.com/repos/aws-controllers-k8s/runtime/releases/latest | jq -r '.tag_name')
-.DEFAULT_GOAL=run
-EXISTING_CONTROLLER="true"
-DRY_RUN="false"
 
-.PHONY: build, generate, update, init, run, clean
+ROOT_DIR=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+CONTROLLER_DIR=${ROOT_DIR}/../${AWS_SERVICE}-controller
+CONTROLLER_BOOTSTRAP=./bin/controller-bootstrap
+CODE_GEN_DIR=${ROOT_DIR}/../code-generator
+
+AWS_SDK_GO_VERSION=$(shell curl -H "Accept: application/vnd.github.v3+json" \
+    https://api.github.com/repos/aws/aws-sdk-go/releases/latest | jq -r '.tag_name')
+ACK_RUNTIME_VERSION=$(shell curl -H "Accept: application/vnd.github.v3+json" \
+    https://api.github.com/repos/aws-controllers-k8s/runtime/releases/latest | jq -r '.tag_name')
+
+.DEFAULT_GOAL=run
+DRY_RUN="false"
+EXISTING_CONTROLLER="true"
+ifeq ($(CONTROLLER_DIR/cmd/controller/main.go),)
+	EXISTING_CONTROLLER="false"
+endif
+
+# Build ldflags
+VERSION ?= "v0.0.0"
+GITCOMMIT=$(shell git rev-parse HEAD)
+BUILDDATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+GO_LDFLAGS=-ldflags "-X main.version=$(VERSION) \
+			-X main.buildHash=$(GITCOMMIT) \
+			-X main.buildDate=$(BUILDDATE)"
+
+# We need to use the codegen tag when building and testing because the
+# aws-sdk-go/private/model/api package is gated behind a build tag "codegen"...
+GO_CMD_FLAGS=-tags codegen
+
+.PHONY: build, generate, init, run, clean
 
 build:
-	@go build ${GO_CMD_FLAGS} -o ${CONTROLLER_BOOTSTRAP} ./cmd/controller-bootstrap/*.go
+	@go build ${GO_CMD_FLAGS} -o ${CONTROLLER_BOOTSTRAP} ./cmd/controller-bootstrap/main.go
 
 generate: build
-	@${CONTROLLER_BOOTSTRAP} generate -s ${AWS_SERVICE} -r ${ACK_RUNTIME_VERSION} -v ${AWS_SDK_GO_VERSION} -d=${DRY_RUN} -o ${ROOT_DIR}/../${AWS_SERVICE}-controller -m ${SERVICE_MODEL_NAME}
-
-update: build
 	@${CONTROLLER_BOOTSTRAP} generate -s ${AWS_SERVICE} -r ${ACK_RUNTIME_VERSION} -v ${AWS_SDK_GO_VERSION} -d=${DRY_RUN} -e=${EXISTING_CONTROLLER} -o ${ROOT_DIR}/../${AWS_SERVICE}-controller -m ${SERVICE_MODEL_NAME}
 
 init: generate
 	@export SERVICE=${AWS_SERVICE}
-	@echo "build controller attempt #1"
 	@cd ${CODE_GEN_DIR} && make -i build-controller >/dev/null 2>/dev/null
-	@echo "missing go.sum entry, running go mod tidy"
 	@cd ${CONTROLLER_DIR} && go mod tidy
-	@echo "build controller attempt #2"
 	@cd ${CODE_GEN_DIR} && make -i build-controller >/dev/null 2>/dev/null
-	@echo "go.sum outdated, running go mod tidy"
 	@cd ${CONTROLLER_DIR} && go mod tidy
-	@echo "final build controller attempt"
 	@cd ${CODE_GEN_DIR} && make build-controller
-	@echo "look inside ${SERVICE}-controller/INSTRUCTIONS.md for further instructions"
+	@echo "${AWS_SERVICE}-controller generated successfully, look inside ${AWS_SERVICE}-controller/INSTRUCTIONS.md for further instructions"
 
 run:
 	@if [ -f ${CONTROLLER_DIR}/cmd/controller/main.go ]; then \
-	  make update; \
+	    make generate; \
 	else \
-	  make init; \
+	    make init; \
 	fi
 
 clean:
-	@cd ${CONTROLLER_DIR}
 	@rm -rf ${CONTROLLER_DIR}/..?* ${CONTROLLER_DIR}/.[!.]* ${CONTROLLER_DIR}/*

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,10 @@ build:
 	@go build ${GO_CMD_FLAGS} -o ${CONTROLLER_BOOTSTRAP} ./cmd/controller-bootstrap/*.go
 
 generate: build
-	@${CONTROLLER_BOOTSTRAP} generate -r ${ACK_RUNTIME_VERSION} -v ${AWS_SDK_GO_VERSION} -s ${AWS_SERVICE} -d=${DRY_RUN} -o ${ROOT_DIR}/../${AWS_SERVICE}-controller -m ${SERVICE_MODEL_NAME}
+	@${CONTROLLER_BOOTSTRAP} generate -s ${AWS_SERVICE} -r ${ACK_RUNTIME_VERSION} -v ${AWS_SDK_GO_VERSION} -d=${DRY_RUN} -o ${ROOT_DIR}/../${AWS_SERVICE}-controller -m ${SERVICE_MODEL_NAME}
 
 update: build
-	@${CONTROLLER_BOOTSTRAP} generate -r ${ACK_RUNTIME_VERSION} -v ${AWS_SDK_GO_VERSION} -s ${AWS_SERVICE} -d=${DRY_RUN} -e=${EXISTING_CONTROLLER} -o ${ROOT_DIR}/../${AWS_SERVICE}-controller -m ${SERVICE_MODEL_NAME}
+	@${CONTROLLER_BOOTSTRAP} generate -s ${AWS_SERVICE} -r ${ACK_RUNTIME_VERSION} -v ${AWS_SDK_GO_VERSION} -d=${DRY_RUN} -e=${EXISTING_CONTROLLER} -o ${ROOT_DIR}/../${AWS_SERVICE}-controller -m ${SERVICE_MODEL_NAME}
 
 init: generate
 	@export SERVICE=${AWS_SERVICE}

--- a/cmd/controller-bootstrap/command/apiutil.go
+++ b/cmd/controller-bootstrap/command/apiutil.go
@@ -1,0 +1,19 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package command
+
+// todo: getServiceResources infers aws-sdk-go to fetch the service metadata and custom resource names
+func getServiceResources() error {
+	return nil
+}

--- a/cmd/controller-bootstrap/command/apiutil.go
+++ b/cmd/controller-bootstrap/command/apiutil.go
@@ -13,7 +13,7 @@
 
 package command
 
-// todo: getServiceResources infers aws-sdk-go to fetch the service metadata and custom resource names
+// TODO: getServiceResources infers aws-sdk-go to fetch the service metadata and custom resource names
 func getServiceResources() error {
 	return nil
 }

--- a/cmd/controller-bootstrap/command/generate.go
+++ b/cmd/controller-bootstrap/command/generate.go
@@ -1,0 +1,29 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package command
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var templateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "generate template files in an ACK service controller repository",
+	RunE:  generateTemplates,
+}
+
+// todo: generateTemplates renders the template files and directories in an ACK service controller repository
+func generateTemplates(cmd *cobra.Command, args []string) error {
+	return nil
+}

--- a/cmd/controller-bootstrap/command/generate.go
+++ b/cmd/controller-bootstrap/command/generate.go
@@ -20,10 +20,13 @@ import (
 var templateCmd = &cobra.Command{
 	Use:   "generate",
 	Short: "generate template files in an ACK service controller repository",
-	RunE:  generateTemplates,
+	RunE:  generateController,
 }
 
-// todo: generateTemplates renders the template files and directories in an ACK service controller repository
-func generateTemplates(cmd *cobra.Command, args []string) error {
+// TODO: generateController creates the initial directories and files for a service controller
+// repository by rendering go template files.
+// When a controller is already existing, then this method only updates the project
+// description files.
+func generateController(cmd *cobra.Command, args []string) error {
 	return nil
 }

--- a/cmd/controller-bootstrap/command/root.go
+++ b/cmd/controller-bootstrap/command/root.go
@@ -26,13 +26,13 @@ const (
 )
 
 var (
-	optDryRun             bool
 	optServiceAlias       string
-	optModelName          string
-	optAWSSDKGoVersion    string
 	optRuntimeVersion     string
+	optAWSSDKGoVersion    string
+	optDryRun             bool
 	optExistingController bool
 	optOutputPath         string
+	optModelName          string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -43,20 +43,17 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.PersistentFlags().BoolVarP(
-		&optDryRun, "dry-run", "d", false, "Optional: if true, output files to stdout",
-	)
 	rootCmd.PersistentFlags().StringVarP(
 		&optServiceAlias, "aws-service-alias", "s", "", "Supplied AWS service alias",
 	)
 	rootCmd.PersistentFlags().StringVarP(
-		&optModelName, "service-model-name", "m", "", "Optional: service model name of the supplied service alias",
+		&optRuntimeVersion, "ack-runtime-version", "r", "", "Version of aws-controllers-k8s/runtime",
 	)
 	rootCmd.PersistentFlags().StringVarP(
 		&optAWSSDKGoVersion, "aws-sdk-go-version", "v", "", "Version of github.com/aws/aws-sdk-go used to infer service metadata and resources",
 	)
-	rootCmd.PersistentFlags().StringVarP(
-		&optRuntimeVersion, "ack-runtime-version", "r", "", "Version of aws-controllers-k8s/runtime",
+	rootCmd.PersistentFlags().BoolVarP(
+		&optDryRun, "dry-run", "d", false, "Optional: if true, output files to stdout",
 	)
 	rootCmd.PersistentFlags().BoolVarP(
 		&optExistingController, "existing-service-controller", "e", false, "Optional: if true, update the existing service controller",
@@ -64,9 +61,12 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(
 		&optOutputPath, "output", "o", "", "Path to ACK service controller directory to bootstrap",
 	)
+	rootCmd.PersistentFlags().StringVarP(
+		&optModelName, "service-model-name", "m", "", "Optional: service model name of the supplied service alias",
+	)
 	rootCmd.MarkPersistentFlagRequired("aws-service-alias")
-	rootCmd.MarkPersistentFlagRequired("aws-sdk-go-version")
 	rootCmd.MarkPersistentFlagRequired("ack-runtime-version")
+	rootCmd.MarkPersistentFlagRequired("aws-sdk-go-version")
 	rootCmd.MarkPersistentFlagRequired("output")
 	rootCmd.AddCommand(templateCmd)
 }

--- a/cmd/controller-bootstrap/command/root.go
+++ b/cmd/controller-bootstrap/command/root.go
@@ -1,0 +1,82 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package command
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	appName      = "controller-bootstrap"
+	appShortDesc = "A bootstrap tool to initialize an ACK service controller repository"
+)
+
+var (
+	optDryRun             bool
+	optServiceAlias       string
+	optModelName          string
+	optAWSSDKGoVersion    string
+	optRuntimeVersion     string
+	optExistingController bool
+	optOutputPath         string
+)
+
+// rootCmd represents the base command when called without any subcommands
+// placeholder for cobra description
+var rootCmd = &cobra.Command{
+	Use:   appName,
+	Short: appShortDesc,
+}
+
+func init() {
+	rootCmd.PersistentFlags().BoolVarP(
+		&optDryRun, "dry-run", "d", false, "Optional: if true, output files to stdout",
+	)
+	rootCmd.PersistentFlags().StringVarP(
+		&optServiceAlias, "aws-service-alias", "s", "", "Supplied AWS service alias",
+	)
+	rootCmd.PersistentFlags().StringVarP(
+		&optModelName, "service-model-name", "m", "", "Optional: service model name of the supplied service alias",
+	)
+	rootCmd.PersistentFlags().StringVarP(
+		&optAWSSDKGoVersion, "aws-sdk-go-version", "v", "", "Version of github.com/aws/aws-sdk-go used to infer service metadata and resources",
+	)
+	rootCmd.PersistentFlags().StringVarP(
+		&optRuntimeVersion, "ack-runtime-version", "r", "", "Version of aws-controllers-k8s/runtime",
+	)
+	rootCmd.PersistentFlags().BoolVarP(
+		&optExistingController, "existing-service-controller", "e", false, "Optional: if true, update the existing service controller",
+	)
+	rootCmd.PersistentFlags().StringVarP(
+		&optOutputPath, "output", "o", "", "Path to ACK service controller directory to bootstrap",
+	)
+	rootCmd.MarkPersistentFlagRequired("aws-service-alias")
+	rootCmd.MarkPersistentFlagRequired("aws-sdk-go-version")
+	rootCmd.MarkPersistentFlagRequired("ack-runtime-version")
+	rootCmd.MarkPersistentFlagRequired("output")
+	rootCmd.AddCommand(templateCmd)
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/controller-bootstrap/command/root.go
+++ b/cmd/controller-bootstrap/command/root.go
@@ -44,7 +44,7 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(
-		&optServiceAlias, "aws-service-alias", "s", "", "Supplied AWS service alias",
+		&optServiceAlias, "aws-service-alias", "s", "", "AWS service alias",
 	)
 	rootCmd.PersistentFlags().StringVarP(
 		&optRuntimeVersion, "ack-runtime-version", "r", "", "Version of aws-controllers-k8s/runtime",
@@ -56,13 +56,13 @@ func init() {
 		&optDryRun, "dry-run", "d", false, "Optional: if true, output files to stdout",
 	)
 	rootCmd.PersistentFlags().BoolVarP(
-		&optExistingController, "existing-service-controller", "e", false, "Optional: if true, update the existing service controller",
+		&optExistingController, "existing-controller", "e", false, "Optional: if true, update the existing service controller",
 	)
 	rootCmd.PersistentFlags().StringVarP(
 		&optOutputPath, "output", "o", "", "Path to ACK service controller directory to bootstrap",
 	)
 	rootCmd.PersistentFlags().StringVarP(
-		&optModelName, "service-model-name", "m", "", "Optional: service model name of the supplied service alias",
+		&optModelName, "model-name", "m", "", "Optional: service model name of the corresponding service alias",
 	)
 	rootCmd.MarkPersistentFlagRequired("aws-service-alias")
 	rootCmd.MarkPersistentFlagRequired("ack-runtime-version")

--- a/cmd/controller-bootstrap/main.go
+++ b/cmd/controller-bootstrap/main.go
@@ -1,0 +1,20 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import "controller-bootstrap/cmd/controller-bootstrap/command"
+
+func main() {
+	command.Execute()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module controller-bootstrap
+
+go 1.18
+
+require github.com/spf13/cobra v1.5.0
+
+require (
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
+github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.5.0 h1:X+jTBEBqF0bHN+9cSMgmfuvv2VHJ9ezmFNf9Y/XstYU=
+github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
Issue: [aws-controllers-k8s/community/issues/1358](https://github.com/aws-controllers-k8s/community/issues/1358)

Description of changes:

- This PR is to add the initial implementation of controller-bootstrap CLI with subcommand, arguments, and Makefile.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
