### PR TITLE
Make `aws-sdk-go`, ACK runtime versions, test-infra commit SHA configurable in Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,11 @@ CONTROLLER_DIR=${ROOT_DIR}/../${AWS_SERVICE}-controller
 CONTROLLER_BOOTSTRAP=./bin/controller-bootstrap
 CODE_GEN_DIR=${ROOT_DIR}/../code-generator
 
-ACK_RUNTIME_VERSION=$(or $(shell echo $(RUNTIME_VERSION)),$(shell curl -H "Accept: application/vnd.github.v3+json" \
+ACK_RUNTIME_VERSION=$(or $(shell echo $(ACK_RUNTIME_VERSION)),$(shell curl -H "Accept: application/vnd.github.v3+json" \
     https://api.github.com/repos/aws-controllers-k8s/runtime/releases/latest | jq -r '.tag_name'))
-AWS_SDK_GO_VERSION=$(or $(shell echo $(SDK_VERSION)),$(shell curl -H "Accept: application/vnd.github.v3+json" \
+AWS_SDK_GO_VERSION=$(or $(shell echo $(AWS_SDK_GO_VERSION)),$(shell curl -H "Accept: application/vnd.github.v3+json" \
     https://api.github.com/repos/aws/aws-sdk-go/releases/latest | jq -r '.tag_name'))
-TEST_INFRA_COMMIT_SHA=$(or $(shell echo $(COMMIT_SHA)),$(shell curl -H "Accept: application/vnd.github.v3+json" \
+TEST_INFRA_COMMIT_SHA=$(or $(shell echo $(TEST_INFRA_COMMIT_SHA)),$(shell curl -H "Accept: application/vnd.github.v3+json" \
     https://api.github.com/repos/aws-controllers-k8s/test-infra/commits | jq -r ".[0].sha"))
 
 .DEFAULT_GOAL=run

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ generate: build
     --model-name ${SERVICE_MODEL_NAME} --test-infra-commit-sha ${TEST_INFRA_COMMIT_SHA}
 
 init: generate
-	@export SERVICE=${AWS_SERVICE}
 	@cd ${CODE_GEN_DIR} && make -i build-controller >/dev/null 2>/dev/null
 	@cd ${CONTROLLER_DIR} && go mod tidy
 	@cd ${CODE_GEN_DIR} && make -i build-controller >/dev/null 2>/dev/null

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,11 @@ CONTROLLER_DIR=${ROOT_DIR}/../${AWS_SERVICE}-controller
 CONTROLLER_BOOTSTRAP=./bin/controller-bootstrap
 CODE_GEN_DIR=${ROOT_DIR}/../code-generator
 
-ACK_RUNTIME_VERSION:=$(or $(shell echo $(ACK_RUNTIME_VERSION)),$(shell curl -H "Accept: application/vnd.github.v3+json" \
+ACK_RUNTIME_VERSION:=$(or $(ACK_RUNTIME_VERSION),$(shell curl -s -H "Accept: application/vnd.github.v3+json" \
     https://api.github.com/repos/aws-controllers-k8s/runtime/releases/latest | jq -r '.tag_name'))
-AWS_SDK_GO_VERSION:=$(or $(shell echo $(AWS_SDK_GO_VERSION)),$(shell curl -H "Accept: application/vnd.github.v3+json" \
+AWS_SDK_GO_VERSION:=$(or $(AWS_SDK_GO_VERSION),$(shell curl -s -H "Accept: application/vnd.github.v3+json" \
     https://api.github.com/repos/aws/aws-sdk-go/releases/latest | jq -r '.tag_name'))
-TEST_INFRA_COMMIT_SHA:=$(or $(shell echo $(TEST_INFRA_COMMIT_SHA)),$(shell curl -H "Accept: application/vnd.github.v3+json" \
+TEST_INFRA_COMMIT_SHA:=$(or $(TEST_INFRA_COMMIT_SHA),$(shell curl -s -H "Accept: application/vnd.github.v3+json" \
     https://api.github.com/repos/aws-controllers-k8s/test-infra/commits | jq -r ".[0].sha"))
 
 .DEFAULT_GOAL=run

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,11 @@ CONTROLLER_DIR=${ROOT_DIR}/../${AWS_SERVICE}-controller
 CONTROLLER_BOOTSTRAP=./bin/controller-bootstrap
 CODE_GEN_DIR=${ROOT_DIR}/../code-generator
 
-ACK_RUNTIME_VERSION=$(or $(shell echo $(ACK_RUNTIME_VERSION)),$(shell curl -H "Accept: application/vnd.github.v3+json" \
+ACK_RUNTIME_VERSION:=$(or $(shell echo $(ACK_RUNTIME_VERSION)),$(shell curl -H "Accept: application/vnd.github.v3+json" \
     https://api.github.com/repos/aws-controllers-k8s/runtime/releases/latest | jq -r '.tag_name'))
-AWS_SDK_GO_VERSION=$(or $(shell echo $(AWS_SDK_GO_VERSION)),$(shell curl -H "Accept: application/vnd.github.v3+json" \
+AWS_SDK_GO_VERSION:=$(or $(shell echo $(AWS_SDK_GO_VERSION)),$(shell curl -H "Accept: application/vnd.github.v3+json" \
     https://api.github.com/repos/aws/aws-sdk-go/releases/latest | jq -r '.tag_name'))
-TEST_INFRA_COMMIT_SHA=$(or $(shell echo $(TEST_INFRA_COMMIT_SHA)),$(shell curl -H "Accept: application/vnd.github.v3+json" \
+TEST_INFRA_COMMIT_SHA:=$(or $(shell echo $(TEST_INFRA_COMMIT_SHA)),$(shell curl -H "Accept: application/vnd.github.v3+json" \
     https://api.github.com/repos/aws-controllers-k8s/test-infra/commits | jq -r ".[0].sha"))
 
 .DEFAULT_GOAL=run

--- a/Makefile
+++ b/Makefile
@@ -8,24 +8,22 @@ SERVICE_MODEL_NAME=$(shell echo $(MODEL_NAME))
 ifeq ($(SERVICE_MODEL_NAME),)
   SERVICE_MODEL_NAME=""
 endif
-AWS_SDK_GO_VERSION=$(shell echo $(SDK_VERSION))
-ACK_RUNTIME_VERSION=$(shell echo $(RUNTIME_VERSION))
-TEST_INFRA_COMMIT_SHA=$(shell echo $(COMMIT_SHA))
 
 ROOT_DIR=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 CONTROLLER_DIR=${ROOT_DIR}/../${AWS_SERVICE}-controller
 CONTROLLER_BOOTSTRAP=./bin/controller-bootstrap
 CODE_GEN_DIR=${ROOT_DIR}/../code-generator
 
-AWS_SDK_GO_VERSION?=$(shell curl -H "Accept: application/vnd.github.v3+json" \
-    https://api.github.com/repos/aws/aws-sdk-go/releases/latest | jq -r '.tag_name')
-ACK_RUNTIME_VERSION?=$(shell curl -H "Accept: application/vnd.github.v3+json" \
-    https://api.github.com/repos/aws-controllers-k8s/runtime/releases/latest | jq -r '.tag_name')
-TEST_INFRA_COMMIT_SHA?=$(shell curl -H "Accept: application/vnd.github.v3+json" \
-    https://api.github.com/repos/aws-controllers-k8s/test-infra/commits | jq -r ".[0].sha")
+ACK_RUNTIME_VERSION=$(or $(shell echo $(RUNTIME_VERSION)),$(shell curl -H "Accept: application/vnd.github.v3+json" \
+    https://api.github.com/repos/aws-controllers-k8s/runtime/releases/latest | jq -r '.tag_name'))
+AWS_SDK_GO_VERSION=$(or $(shell echo $(SDK_VERSION)),$(shell curl -H "Accept: application/vnd.github.v3+json" \
+    https://api.github.com/repos/aws/aws-sdk-go/releases/latest | jq -r '.tag_name'))
+TEST_INFRA_COMMIT_SHA=$(or $(shell echo $(COMMIT_SHA)),$(shell curl -H "Accept: application/vnd.github.v3+json" \
+    https://api.github.com/repos/aws-controllers-k8s/test-infra/commits | jq -r ".[0].sha"))
 
 .DEFAULT_GOAL=run
 DRY_RUN="false"
+REFRESH_CACHE="true"
 
 # Build ldflags
 VERSION ?= "v0.0.0"
@@ -47,7 +45,7 @@ build:
 generate: build
 	@${CONTROLLER_BOOTSTRAP} generate --aws-service-alias ${AWS_SERVICE} --ack-runtime-version ${ACK_RUNTIME_VERSION} \
     --aws-sdk-go-version ${AWS_SDK_GO_VERSION} --dry-run=${DRY_RUN} --output-path ${ROOT_DIR}/../${AWS_SERVICE}-controller \
-    --model-name ${SERVICE_MODEL_NAME} --test-infra-commit-sha ${TEST_INFRA_COMMIT_SHA}
+    --model-name ${SERVICE_MODEL_NAME} --refresh-cache=${REFRESH_CACHE} --test-infra-commit-sha ${TEST_INFRA_COMMIT_SHA}
 
 init: generate
 	@export SERVICE=${AWS_SERVICE}
@@ -56,7 +54,7 @@ init: generate
 	@cd ${CODE_GEN_DIR} && make -i build-controller >/dev/null 2>/dev/null
 	@cd ${CONTROLLER_DIR} && go mod tidy
 	@cd ${CODE_GEN_DIR} && make build-controller
-	@echo "${AWS_SERVICE}-controller generated successfully, look inside ${AWS_SERVICE}-controller/INSTRUCTIONS.md for further instructions"
+	@echo "${AWS_SERVICE}-controller generated successfully, look inside ${AWS_SERVICE}-controller/READ_BEFORE_COMMIT.md for further instructions"
 
 run:
 	@if [ -f ${CONTROLLER_DIR}/cmd/controller/main.go ]; then \

--- a/Makefile
+++ b/Makefile
@@ -45,12 +45,12 @@ build:
 	@go build ${GO_CMD_FLAGS} -o ${CONTROLLER_BOOTSTRAP} ./cmd/controller-bootstrap/main.go
 
 generate: build
-	echo "print this ${ACK_RUNTIME_VERSION}"
 	@${CONTROLLER_BOOTSTRAP} generate --aws-service-alias ${AWS_SERVICE} --ack-runtime-version ${ACK_RUNTIME_VERSION} \
     --aws-sdk-go-version ${AWS_SDK_GO_VERSION} --dry-run=${DRY_RUN} --output-path ${ROOT_DIR}/../${AWS_SERVICE}-controller \
     --model-name ${SERVICE_MODEL_NAME} --test-infra-commit-sha ${TEST_INFRA_COMMIT_SHA}
 
 init: generate
+	@export SERVICE=${AWS_SERVICE}
 	@cd ${CODE_GEN_DIR} && make -i build-controller >/dev/null 2>/dev/null
 	@cd ${CONTROLLER_DIR} && go mod tidy
 	@cd ${CODE_GEN_DIR} && make -i build-controller >/dev/null 2>/dev/null


### PR DESCRIPTION
Issue: [aws-controllers-k8s/community/issues/1358](https://github.com/aws-controllers-k8s/community/issues/1358)

Description of changes:

- This PR is to make `aws-sdk-go` version, ACK runtime version, and ACK test-infra commit SHA configurable in `Makefile`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
