### PR TITLE
Modify required parameters as arguments to the `generate` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,9 @@ build:
 	@go build ${GO_CMD_FLAGS} -o ${CONTROLLER_BOOTSTRAP} ./cmd/controller-bootstrap/main.go
 
 generate: build
-	@${CONTROLLER_BOOTSTRAP} generate --aws-service-alias ${AWS_SERVICE} --ack-runtime-version ${ACK_RUNTIME_VERSION} \
-    --aws-sdk-go-version ${AWS_SDK_GO_VERSION} --dry-run=${DRY_RUN} --output-path ${ROOT_DIR}/../${AWS_SERVICE}-controller \
-    --model-name ${SERVICE_MODEL_NAME} --refresh-cache=${REFRESH_CACHE} --test-infra-commit-sha ${TEST_INFRA_COMMIT_SHA}
+	@${CONTROLLER_BOOTSTRAP} generate ${AWS_SDK_GO_VERSION} ${ACK_RUNTIME_VERSION} ${TEST_INFRA_COMMIT_SHA} \
+    --aws-service-alias ${AWS_SERVICE} --dry-run=${DRY_RUN} --output-path ${ROOT_DIR}/../${AWS_SERVICE}-controller \
+    --model-name ${SERVICE_MODEL_NAME} --refresh-cache=${REFRESH_CACHE}
 
 init: generate
 	@export SERVICE=${AWS_SERVICE}

--- a/cmd/controller-bootstrap/command/common.go
+++ b/cmd/controller-bootstrap/command/common.go
@@ -165,8 +165,7 @@ func ensureSemverPrefix(s string) string {
 	return fmt.Sprintf("v%s", s)
 }
 
-// getSDKVersion returns the github.com/aws/aws-sdk-go version to use
-// from the --aws-sdk-go-version flag.
+// getSDKVersion returns the github.com/aws/aws-sdk-go version
 func getSDKVersion() string {
-	return optAWSSDKGoVersion
+	return awsSDKGoVersion
 }

--- a/cmd/controller-bootstrap/command/root.go
+++ b/cmd/controller-bootstrap/command/root.go
@@ -27,17 +27,14 @@ const (
 )
 
 var (
-	optRuntimeVersion     string
-	optAWSSDKGoVersion    string
-	optTestInfraCommitSHA string
-	optModelName          string
-	optRefreshCache       bool
-	optServiceAlias       string
-	optDryRun             bool
-	optOutputPath         string
-	sdkDir                string
-	defaultCacheACKDir    string
-	defaultTemplatesDir   string
+	sdkDir              string
+	defaultCacheACKDir  string
+	defaultTemplatesDir string
+	optModelName        string
+	optRefreshCache     bool
+	optServiceAlias     string
+	optDryRun           bool
+	optOutputPath       string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -63,15 +60,6 @@ func init() {
 	defaultTemplatesDir = filepath.Join(cd, "templates")
 
 	templateCmd.PersistentFlags().StringVar(
-		&optRuntimeVersion, "ack-runtime-version", "", "Version of aws-controllers-k8s/runtime",
-	)
-	templateCmd.PersistentFlags().StringVar(
-		&optAWSSDKGoVersion, "aws-sdk-go-version", "", "Version of github.com/aws/aws-sdk-go used to infer service metadata and resources",
-	)
-	templateCmd.PersistentFlags().StringVar(
-		&optTestInfraCommitSHA, "test-infra-commit-sha", "", "Commit SHA of aws-controllers-k8s/test-infra",
-	)
-	templateCmd.PersistentFlags().StringVar(
 		&optModelName, "model-name", "", "Optional: service model name of the corresponding service alias",
 	)
 	templateCmd.PersistentFlags().BoolVar(
@@ -86,9 +74,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(
 		&optOutputPath, "output-path", "", "Path to ACK service controller directory to bootstrap",
 	)
-	templateCmd.MarkPersistentFlagRequired("ack-runtime-version")
-	templateCmd.MarkPersistentFlagRequired("aws-sdk-go-version")
-	templateCmd.MarkPersistentFlagRequired("test-infra-commit-sha")
 	rootCmd.MarkPersistentFlagRequired("aws-service-alias")
 	rootCmd.MarkPersistentFlagRequired("output-path")
 	rootCmd.AddCommand(templateCmd)


### PR DESCRIPTION
Signed-off-by: James Park <jamesjhp@amazon.com>

Issue: [aws-controllers-k8s/community/issues/1358](https://github.com/aws-controllers-k8s/community/issues/1358)

Description of changes:

- This PR is to modify the required parameters be arguments to the `generate` command instead of flags.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
