### PR TITLE
updating the url value in the olm template

### DIFF
--- a/templates/olm/olmconfig.yaml.tpl
+++ b/templates/olm/olmconfig.yaml.tpl
@@ -31,4 +31,4 @@ maintainers:
   email: "ack-maintainers@amazon.com"
 links:
 - name: Amazon {{ .ServiceID }} Developer Resources
-  url: "{YOUR SERVICE DEVELOPER RESOURCES URL}"
+  url: https://aws.amazon.com/{{ .ServiceID }}/developer-resources/


### PR DESCRIPTION
Issue #, if available:
- Relates: aws-controllers-k8s/community#1556

Description of changes:
Updating the `url` value to be a valid url, so that this does not cause `operator-sdk` to error out and fail builds. For most services I've seen the below formate to be valid, or there is usually a redirect URL for this route.  I figure this is a good starting point for most services, but we can change this if need be after the fact. Since I think a wrong URL is better then broken builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Adam D. Cornett <adc@redhat.com>