### PR TITLE
update go.mod.tpl for modern values

### DIFF
--- a/go.mod.tpl
+++ b/go.mod.tpl
@@ -1,15 +1,12 @@
 module github.com/aws-controllers-k8s/{{ .Service.Name.Lower }}-controller
 
-go 1.14
+go 1.19
 
 require (
-	github.com/aws/aws-controllers-k8s v0.0.2
-	github.com/aws/aws-sdk-go v1.35.5
-	github.com/go-logr/logr v0.1.0
-	github.com/google/go-cmp v0.3.1
+	github.com/aws-controllers-k8s/runtime v0.24.0
+	github.com/aws/aws-sdk-go v1.44.214
 	github.com/spf13/pflag v1.0.5
-	k8s.io/api v0.18.2
-	k8s.io/apimachinery v0.18.6
-	k8s.io/client-go v0.18.2
-	sigs.k8s.io/controller-runtime v0.6.0
+	k8s.io/apimachinery v0.23.0
+	k8s.io/client-go v0.23.0
+	sigs.k8s.io/controller-runtime v0.11.0
 )


### PR DESCRIPTION
We had an old Go version (1.14) and ancient deps listed in the default go.mod.tpl file. This updates to a more modern set of deps and Go version (1.19) which results in fewer iterations of `go mod tidy` when generating a bootstrapped controller.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
