### PR TITLE
adding in pre install steps to olm config template

### DIFF
--- a/templates/olm/olmconfig.yaml.tpl
+++ b/templates/olm/olmconfig.yaml.tpl
@@ -21,6 +21,12 @@ description: |-
 
   This controller is a component of the [AWS Controller for Kubernetes](https://github.com/aws/aws-controllers-k8s)
   project. This project is currently in **developer preview**.
+
+
+  **Pre-Installation Steps**
+
+
+  Please follow the following link: [Red Hat OpenShift](https://aws-controllers-k8s.github.io/community/docs/user-docs/openshift/)
 samples:
 - kind: ExampleCustomKind
   spec: '{}'


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
I just realized that all newly created projects were missing the pre-install steps for OpenShift, so adding that to this template.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
