### PR TITLE
Update OWNERS files to reflect current team

### DIFF
--- a/templates/OWNERS.tpl
+++ b/templates/OWNERS.tpl
@@ -2,4 +2,3 @@
 
 approvers:
   - core-ack-team
-  - service-team

--- a/templates/OWNERS_ALIASES.tpl
+++ b/templates/OWNERS_ALIASES.tpl
@@ -3,7 +3,7 @@
 aliases:
   core-ack-team:
     - a-hilaly
-    - RedbackThomson
-    - jljaco
-  # TODO: Add your team members' GitHub aliases to the team alias
-  service-team: []
+    - jlbutler
+    - michaelhtm
+    - rushmash91
+    - knottnt


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Remove `service-team`
- Default OWNERS_ALIASES to current team members 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
