### PR TITLE
Add optional github token to avoid throttling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,14 @@ SHELL := /bin/bash # Use bash syntax
 # Set up variables
 GO111MODULE=on
 
+# Allow GITHUB_TOKEN to be passed in via CLI or environment
+# Usage: make generate GITHUB_TOKEN=ghp_yourtokenhere
+GITHUB_TOKEN ?=
+
+# Helper to construct the Authorization header if the token exists
+AUTH_HEADER := $(if $(GITHUB_TOKEN),-H "Authorization: Bearer $(GITHUB_TOKEN)",)
+GITHUB_API_H := -H "Accept: application/vnd.github.v3+json" $(AUTH_HEADER)
+
 AWS_SERVICE=$(shell echo $(SERVICE))
 SERVICE_MODEL_NAME=$(shell echo $(MODEL_NAME))
 ifeq ($(SERVICE_MODEL_NAME),)
@@ -14,11 +22,11 @@ CONTROLLER_BOOTSTRAP=./bin/controller-bootstrap
 CODE_GEN_DIR=${ROOT_DIR}/../code-generator
 
 CONTROLLER_DIR:=$(or $(CONTROLLER_DIR),${ROOT_DIR}/../${AWS_SERVICE}-controller)
-ACK_RUNTIME_VERSION:=$(or $(ACK_RUNTIME_VERSION),$(shell curl -s -H "Accept: application/vnd.github.v3+json" \
+ACK_RUNTIME_VERSION:=$(or $(ACK_RUNTIME_VERSION),$(shell curl -s $(GITHUB_API_H) \
     https://api.github.com/repos/aws-controllers-k8s/runtime/releases/latest | jq -r '.tag_name'))
-AWS_SDK_GO_VERSION:=$(or $(AWS_SDK_GO_VERSION),$(shell curl -s -H "Accept: application/vnd.github.v3+json" \
+AWS_SDK_GO_VERSION:=$(or $(AWS_SDK_GO_VERSION),$(shell curl -s $(GITHUB_API_H) \
     https://api.github.com/repos/aws/aws-sdk-go/releases/latest | jq -r '.tag_name'))
-TEST_INFRA_COMMIT_SHA:=$(or $(TEST_INFRA_COMMIT_SHA),$(shell curl -s -H "Accept: application/vnd.github.v3+json" \
+TEST_INFRA_COMMIT_SHA:=$(or $(TEST_INFRA_COMMIT_SHA),$(shell curl -s $(GITHUB_API_H) \
     https://api.github.com/repos/aws-controllers-k8s/test-infra/commits | jq -r ".[0].sha"))
 
 .DEFAULT_GOAL=run
@@ -43,6 +51,12 @@ build:
 	@go build ${GO_CMD_FLAGS} -o ${CONTROLLER_BOOTSTRAP} ./cmd/controller-bootstrap/main.go
 
 generate: build
+# 	log variables for debugging
+	@echo "Generating ${AWS_SERVICE}-controller with the following parameters:"
+	@echo "  CONTROLLER_DIR=${CONTROLLER_DIR}"
+	@echo "  ACK_RUNTIME_VERSION=${ACK_RUNTIME_VERSION}"
+	@echo "  AWS_SDK_GO_VERSION=${AWS_SDK_GO_VERSION}"
+	@echo "  SERVICE_MODEL_NAME=${SERVICE_MODEL_NAME}"	
 	@${CONTROLLER_BOOTSTRAP} generate --aws-service-alias ${AWS_SERVICE} --ack-runtime-version ${ACK_RUNTIME_VERSION} \
     --aws-sdk-go-version ${AWS_SDK_GO_VERSION} --dry-run=${DRY_RUN} --output-path ${CONTROLLER_DIR} \
     --model-name ${SERVICE_MODEL_NAME} --refresh-cache=${REFRESH_CACHE} --test-infra-commit-sha ${TEST_INFRA_COMMIT_SHA}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Add optional github token to avoid throttling on api when retrieving tags and commits from github
- Added debugging logs when running build target

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
