### PR TITLE
Add core reviewers to OWNERS Template

### DIFF
--- a/cmd/controller-bootstrap/command/apiutil.go
+++ b/cmd/controller-bootstrap/command/apiutil.go
@@ -160,6 +160,7 @@ func loadAPI(modelPath string) (*metaVars, error) {
 			}
 
 			svcVars.ServiceID = serviceId.(string)
+			svcVars.ServicePackageName = optServiceAlias
 			svcVars.ServiceFullName = serviceTitle
 			svcVars.ServiceAbbreviation = serviceTitle
 

--- a/cmd/controller-bootstrap/command/update.go
+++ b/cmd/controller-bootstrap/command/update.go
@@ -31,6 +31,8 @@ var projectDescriptionFiles = []string{
 	"LICENSE.tpl",
 	"NOTICE.tpl",
 	"SECURITY.md.tpl",
+	"OWNERS.tpl",
+	"OWNERS_ALIASES.tpl",
 }
 
 var updateCmd = &cobra.Command{

--- a/templates/.gitignore.tpl
+++ b/templates/.gitignore.tpl
@@ -2,6 +2,7 @@
 *.swp
 *~
 .idea
+.vscode
 bin
 build
 .env

--- a/templates/OWNERS.tpl
+++ b/templates/OWNERS.tpl
@@ -2,3 +2,6 @@
 
 approvers:
   - core-ack-team
+
+reviewers:
+  - core-ack-reviewers

--- a/templates/OWNERS_ALIASES.tpl
+++ b/templates/OWNERS_ALIASES.tpl
@@ -6,3 +6,7 @@ aliases:
     - jlbutler
     - michaelhtm
     - knottnt
+
+  core-ack-reviewers:
+    - gustavodiaz7722
+

--- a/templates/OWNERS_ALIASES.tpl
+++ b/templates/OWNERS_ALIASES.tpl
@@ -6,6 +6,15 @@ aliases:
     - jlbutler
     - michaelhtm
     - knottnt
+  # emeritus-core-ack-team:
+  #   - rushmash91
+  #   - jaypipes
+  #   - jljaco
+  #   - mhausenblas
+  #   - RedbackThomson
+  #   - TiberiuGC
+  #   - vijtrip2
+  #   - ivelichkovich
 
   core-ack-reviewers:
     - gustavodiaz7722


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Update OWNERS and OWNERS_ALIASES template file to include core-ack-reviewers
- Fix issue where ServicePackageName was not populated causing issues in go.mod generation
- Add .vscode to default .gitignore file
- Include OWNERS and OWNERS_ALIASES templates to `controller-bootstrap update`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
